### PR TITLE
eigener handle aus log; anzeige der HE nur für player; suchen für HE nur für sich selbst

### DIFF
--- a/Source/Star Citizen Handle Query/Serialization/LogMonitorInfo.cs
+++ b/Source/Star Citizen Handle Query/Serialization/LogMonitorInfo.cs
@@ -40,13 +40,19 @@ namespace Star_Citizen_Handle_Query.Serialization {
     public bool IsValid { get { return Date > DateTime.MinValue; } }
 
     public override bool Equals(object obj) {
-      if (obj != null && obj is LogMonitorInfo lmi) {
+      if (obj != null && obj is LogMonitorInfo lmi)
+      {
+        // zwei events gleichen sich, obwohl der handle unterschiedlich ist
+        // -> multicrewschiffe haben mehrere handles, aber das selbe schiff (value) und den selben attacker (key)
+        var areEqualHostilityEvents = lmi.LogType == LogType.HostilityEvent && lmi.LogType == LogType && lmi.Value == Value && lmi.Key == Key &&
+                                  lmi.Date <= Date && lmi.Date.AddSeconds(10) >= Date;
         return lmi.Handle == Handle &&
-          lmi.Date <= Date && lmi.Date.AddSeconds(10) >= Date &&
-          (lmi.LogType == LogType ||
-          (lmi.LogType == LogType.ActorDeath && LogType == LogType.Corpse) ||
-          (lmi.LogType == LogType.Corpse && LogType == LogType.ActorDeath)) &&
-          (lmi.LogType != LogType.HostilityEvent || lmi.Key == Key);
+               lmi.Date <= Date && lmi.Date.AddSeconds(10) >= Date &&
+               (lmi.LogType == LogType ||
+                (lmi.LogType == LogType.ActorDeath && LogType == LogType.Corpse) ||
+                (lmi.LogType == LogType.Corpse && LogType == LogType.ActorDeath) ||
+                lmi.LogType == LogType.ActorDeath && LogType == LogType.Corpse) ||
+               areEqualHostilityEvents;
       } else {
         return base.Equals(obj);
       }
@@ -65,6 +71,7 @@ namespace Star_Citizen_Handle_Query.Serialization {
   public enum LogType {
     Corpse,
     LoadingScreenDuration,
+    OwnHandleInfo,
     ActorDeath,
     HostilityEvent
   }

--- a/Source/Star Citizen Handle Query/Serialization/Settings.cs
+++ b/Source/Star Citizen Handle Query/Serialization/Settings.cs
@@ -240,6 +240,7 @@ namespace Star_Citizen_Handle_Query.Serialization {
     /// <summary>Globale NPC-Namen</summary>
     public readonly List<string> Global_NPC_Filter = [
       "NPC_",
+      "AIModule_",
       "PU_",
       "Kopion_",
       "Quasigrazer_",
@@ -268,6 +269,9 @@ namespace Star_Citizen_Handle_Query.Serialization {
     /// <summary>Angabe, ob Ladezeiten angezeigt werden sollen</summary>
     public bool LoadingScreenDuration { get; set; } = false;
 
+    /// <summary>Eigener Handle</summary>
+    public string OwnHandle { get; set; } = "";
+    
     /// <summary>Angabe, ob Feindseligkeitsereignisse angezeigt werden sollen</summary>
     public bool Hostility_Events { get; set; } = true;
 

--- a/Source/Star Citizen Handle Query/UserControls/UserControlLog.cs
+++ b/Source/Star Citizen Handle Query/UserControls/UserControlLog.cs
@@ -51,37 +51,43 @@ namespace Star_Citizen_Handle_Query.UserControls {
           break;
         case LogType.LoadingScreenDuration:
           LabelText.Text = $"Loading screen: {LogInfoItem.Value}s";
+          break;    
+        case LogType.OwnHandleInfo:
+          InitLogItemLayout();
+          LabelText.Text = $"Own handle is: {Environment.NewLine}{LogInfoItem.Handle}";
           break;
         case LogType.ActorDeath:
+          InitLogItemLayout();
+          SetAndQueryHandle(LogInfoItem.Handle);
+          break;
         case LogType.HostilityEvent:
-          LabelText.Text = $"{LogInfoItem.Handle}{Environment.NewLine}{LogInfoItem.Key}";
-          SetToolTip(LogInfoItem.Value);
-          if (LogInfoItem.RelationValue > RelationValue.NotAssigned) {
-            LabelRelation.Visible = LogInfoItem.RelationValue > RelationValue.NotAssigned;
-            LabelRelation.BackColor = FormHandleQuery.GetRelationColor(ProgramSettings, LogInfoItem.RelationValue);
-          }
-          Height += LabelText.Height;
-          LabelRelation.Height += LabelText.Height;
-          LabelText.Height *= 2;
-          LabelTime.Text += $"{Environment.NewLine}❌";
-          LabelTime.Height *= 2;
-          AddMouseEvents();
-
-          // Ggf. Handle-Suche direkt durchführen
-          if (ProgramSettings.LogMonitor.HandleFilter != null && ProgramSettings.LogMonitor.HandleFilter.Count > 0) {
-            if (ProgramSettings.LogMonitor.HandleFilter.Any(h => h.Equals(LogInfoItem.Handle, StringComparison.CurrentCultureIgnoreCase))) {
+          InitLogItemLayout();
+          // Handle-Suche direkt durchführen
+          // hostility events handles nur suchen, wenn man selbst betroffen ist; da diese events auch von anderen spielern geloggt werden
+          if (ProgramSettings.LogMonitor.Filter.OwnHandle.Equals(LogInfoItem.Handle)) {
               SetAndQueryHandle(LogInfoItem.Key);
-            } else if (ProgramSettings.LogMonitor.HandleFilter.Any(h => h.Equals(LogInfoItem.Key, StringComparison.CurrentCultureIgnoreCase))) {
+          } else if (ProgramSettings.LogMonitor.Filter.OwnHandle.Equals(LogInfoItem.Key)) {
               SetAndQueryHandle(LogInfoItem.Handle);
-            }
-          } else {
-            SetAndQueryHandle(LogInfoItem.Handle);
           }
-
           break;
       }
 
       TimerRemoveControl.Enabled = true;
+    }
+
+    private void InitLogItemLayout() {
+      LabelText.Text = $"{LogInfoItem.Handle}{Environment.NewLine}{LogInfoItem.Key}";
+      Height += LabelText.Height;
+      LabelRelation.Height += LabelText.Height;
+      LabelText.Height *= 2;
+      LabelTime.Text += $"{Environment.NewLine}❌";
+      LabelTime.Height *= 2;
+      SetToolTip(LogInfoItem.Value);
+      if (LogInfoItem.RelationValue > RelationValue.NotAssigned) {
+        LabelRelation.Visible = LogInfoItem.RelationValue > RelationValue.NotAssigned;
+        LabelRelation.BackColor = FormHandleQuery.GetRelationColor(ProgramSettings, LogInfoItem.RelationValue);
+      }
+      AddMouseEvents();
     }
 
     public void UpdateInfo(LogMonitorInfo info) {


### PR DESCRIPTION
- eigenen handle aus der logdatei auslesen und im log anzeigen;
- eigenen handle als filter für die suche der handles aus den hostility events verwenden;
- npc hostility events werden generell nicht angezeigt (zu viele)